### PR TITLE
Update MainfestAnalyzer.java

### DIFF
--- a/src/main/java/client/manifest/MainfestAnalyzer.java
+++ b/src/main/java/client/manifest/MainfestAnalyzer.java
@@ -97,6 +97,14 @@ public class MainfestAnalyzer extends Analyzer {
 		// get components
 		HashMap<String, ComponentModel> componentMap = getComponentMap(type);
 		for (AXmlNode componentNode : components) {
+			// ignore the component whose "enabled" attribute is "false"
+			if (componentNode.hasAttribute("enabled")) {
+				if (componentNode.getAttribute("enabled").getValue().toString().equals("")
+				 || componentNode.getAttribute("enabled").getValue().toString().equals("false")) {
+					continue;
+				}
+			}
+			
 			// new ActivityData instance
 			String componentName = componentNode.getAttribute("name").getValue().toString();
 			if (!Global.v().getAppModel().getApplicationClassNames().contains(componentName)) {


### PR DESCRIPTION
The component, whose attribute "enabled" is "false", cannot be initialized by Android system, thus, we can ignore the analysis on this type of component.